### PR TITLE
Counterfeit demo polish: resilient watch loop + no-search-URL rule

### DIFF
--- a/examples/counterfeit_detection/main.py
+++ b/examples/counterfeit_detection/main.py
@@ -17,6 +17,7 @@ import time
 import typing
 from typing import Literal
 
+import httpx
 import tyro
 from dotenv import load_dotenv
 from hai_agents import Agent, Client, SessionRunResult, Tool
@@ -38,6 +39,10 @@ from examples.counterfeit_detection.prompts import (
     SWEEP_TASK,
     TOOLED_INSTRUCTIONS,
 )
+
+# A long-poll that read-times-out (or a brief connection drop) shouldn't kill a multi-minute run —
+# the session keeps running server-side, so we resume the watch this many times before giving up.
+_MAX_POLL_RETRIES = 6
 
 
 class ProductInfo(BaseModel):
@@ -161,11 +166,29 @@ def _run_watched(
 
     The platform link is the same for watching the agent act live and replaying the
     finished trajectory, so it is printed once at start and once after completion.
+
+    The agent runs server-side; the client just long-polls for changes. A transient network
+    blip (``httpx.ReadTimeout`` / connection reset) on a single poll otherwise crashes the whole
+    run even though the session is fine — so we resume the wait, which re-polls from the session's
+    current state. Already-answered tool calls are not re-dispatched (the server only advertises
+    still-pending ones).
     """
     handle = client.start_session(tools=tools, **create_params)
     url = f"https://platform.hcompany.ai/agent-view/{handle.id}"
     print(f"session {handle.id}\nwatch live: {url}", file=sys.stderr, flush=True)
-    result = handle.wait_for_completion()
+    for attempt in range(1, _MAX_POLL_RETRIES + 1):
+        try:
+            result = handle.wait_for_completion()
+            break
+        except httpx.TransportError as exc:  # ReadTimeout, ConnectError, RemoteProtocolError, …
+            if attempt == _MAX_POLL_RETRIES:
+                raise
+            print(
+                f"poll dropped ({type(exc).__name__}); agent still running server-side, "
+                f"resuming watch [{attempt}/{_MAX_POLL_RETRIES - 1}]",
+                file=sys.stderr,
+                flush=True,
+            )
     print(f"replay: {url}", file=sys.stderr)
     return result
 

--- a/examples/counterfeit_detection/prompts/ground_rules.md
+++ b/examples/counterfeit_detection/prompts/ground_rules.md
@@ -59,6 +59,19 @@ Confirm a site as counterfeit only when it shows **at least 3** of:
 Always browse the candidate to verify the product actually matches your extracted reference before
 confirming.
 
+## What you must report as the counterfeit URL
+
+The `counterfeit_url` you return MUST be the **actual merchant/product/listing page you opened and
+inspected** — e.g. `https://shop-xyz.vip/product/123` or a specific marketplace listing URL.
+
+- NEVER report a search-engine results page (`google.com/search?...`, Bing, etc.), a marketplace
+  *search* URL, or any aggregator results page. A list of results is a lead, not a listing.
+- If sponsored/search results clearly point to replicas but you could not open a specific listing
+  (page blocked, render failed), DO NOT return the search URL. Either try another candidate, or
+  report `counterfeit_url = null` with `confidence = "none"` and explain in `reasoning` what you saw.
+- Whenever you return a non-null `counterfeit_url`, populate `red_flags` with the specific flags you
+  observed on that page (don't leave it empty and bury them in prose).
+
 ## Hard safety rules
 
 - NEVER buy anything, add to cart, create an account, or submit any form.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "hai-agent-demos"
+name = "hai-agents-demos"
 version = "0.1.0"
 description = "Demo recipes for the hai-agents Python SDK, wired up as MCP servers for Claude Code."
 readme = "README.md"
@@ -16,8 +16,8 @@ dependencies = [
 ]
 
 [project.scripts]
-hai-agent-demos-qa = "examples.qa.mcp.server:main"
-hai-agent-demos-extract-anything = "examples.extract_anything.server:main"
+hai-agents-demos-qa = "examples.qa.mcp.server:main"
+hai-agents-demos-extract-anything = "examples.extract_anything.server:main"
 debug-qa = "examples.qa.mcp.debug:main"
 qa-cli = "examples.qa.cli.main:main"
 counterfeit-cli = "examples.counterfeit_detection.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "hai-agents-demos"
+name = "hai-agent-demos"
 version = "0.1.0"
 description = "Demo recipes for the hai-agents Python SDK, wired up as MCP servers for Claude Code."
 readme = "README.md"
@@ -12,11 +12,12 @@ dependencies = [
     "python-dotenv>=1.0",
     "openai>=1.40",
     "playwright>=1.40",
+    "httpx>=0.27",         # the SDK's transport; we catch httpx.TransportError to survive poll blips
 ]
 
 [project.scripts]
-hai-agents-demos-qa = "examples.qa.mcp.server:main"
-hai-agents-demos-extract-anything = "examples.extract_anything.server:main"
+hai-agent-demos-qa = "examples.qa.mcp.server:main"
+hai-agent-demos-extract-anything = "examples.extract_anything.server:main"
 debug-qa = "examples.qa.mcp.debug:main"
 qa-cli = "examples.qa.cli.main:main"
 counterfeit-cli = "examples.counterfeit_detection.main:main"

--- a/uv.lock
+++ b/uv.lock
@@ -586,7 +586,7 @@ wheels = [
 ]
 
 [[package]]
-name = "hai-agent-demos"
+name = "hai-agents-demos"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -586,12 +586,13 @@ wheels = [
 ]
 
 [[package]]
-name = "hai-agents-demos"
+name = "hai-agent-demos"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "hai-agents" },
+    { name = "httpx" },
     { name = "openai" },
     { name = "playwright" },
     { name = "pydantic" },
@@ -609,6 +610,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.0" },
     { name = "hai-agents", specifier = ">=0.1.7" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "openai", specifier = ">=1.40" },
     { name = "playwright", specifier = ">=1.40" },
     { name = "pydantic", specifier = ">=2.7" },


### PR DESCRIPTION
Two improvements layered on current `main`.

## 1. Survive transient client-side poll drops (`main.py`)
A single `httpx.ReadTimeout` / connection reset on the long-poll was crashing the whole CLI with a traceback — even though the agent keeps running server-side and the session completes fine. `_run_watched` now catches `httpx.TransportError` and resumes the watch up to 6 times, printing a one-line notice. Adds `httpx` as a direct dep.

> Scope: this handles **client-side** poll drops. It does not prevent a server-side `RemoteBrowserDriver: ReadTimeout` that ends a trajectory (cloud browser failing to capture an observation — a platform-side transient; cure there is a re-run).

## 2. Never report a search-results URL as the counterfeit (`prompts/ground_rules.md`)
A live run returned `google.com/search?q=...replica` as `counterfeit_url` with `red_flags` empty — the agent saw sponsored AliExpress replicas but couldn't open a specific listing, so it handed back the search page. New rule: `counterfeit_url` MUST be an actual merchant/listing page the agent opened (never a search-engine/aggregator results URL); if none could be opened, return `null`; populate `red_flags` whenever `counterfeit_url` is non-null.

## Verification
Ruff + mypy clean. Resilience code was validated live earlier this week. The prompt rule is **not yet live-validated** (confirming run was interrupted) — low-risk instruction tightening; happy to run one `simple` pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)