### PR TITLE
feat: add NemoClaw deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hai-agents-demos
 
-Recipes for the [`hai-agents`](https://pypi.org/project/hai-agents/) Python SDK, wired up as **MCP servers and CLI tools for Claude Code**, and runnable in other MCP hosts ([Hermes Agent](hermes/), [Codex](codex/)) too. Each example shows one way to use the SDK in a real workflow.
+Recipes for the [`hai-agents`](https://pypi.org/project/hai-agents/) Python SDK, wired up as **MCP servers and CLI tools for Claude Code**, and runnable in other MCP hosts ([Hermes Agent](hermes/), [Codex](codex/)), or deployed inside NVIDIA's [NemoClaw](nemoclaw/) sandbox. Each example shows one way to use the SDK in a real workflow.
 
 The SDK lets you spin up autonomous agents — web-surfing, code-running, vision-capable — and drive them from Python. This repo wraps that SDK into two interface patterns so you can call the agents from inside Claude Code while you work:
 
@@ -28,6 +28,10 @@ These demos aren't limited to Claude Code. Hermes Agent consumes the same MCP se
 ### Run in Codex (OpenAI)
 
 Codex is an MCP client too. See [`codex/`](codex/) for the same servers in `config.toml` form, including the hosted platform server via `bearer_token_env_var`. Mind Codex's 60 s default tool timeout.
+
+### Deploy inside NVIDIA NemoClaw
+
+NemoClaw isn't a separate host: it runs Hermes inside an NVIDIA OpenShell sandbox. So this is the Hermes integration deployed there, plus an egress policy that lets the sandboxed agent reach `agp`. See [`nemoclaw/`](nemoclaw/).
 
 ### Installing the dependencies
 
@@ -81,6 +85,7 @@ hai-agents-demos/
 ├── skills/      hai-agents · hai-qa-via-cli (published to the marketplace)
 ├── hermes/      run the same demos in Hermes Agent (config + setup guide)
 ├── codex/       run the same demos in OpenAI Codex (config.toml + setup guide)
+├── nemoclaw/    deploy the Hermes integration inside NVIDIA NemoClaw's sandbox (egress policy + image + guide)
 ├── .mcp.json    registers the MCP servers with Claude Code
 ├── .claude-plugin/marketplace.json
 └── pyproject.toml · AGENTS.md

--- a/nemoclaw/README.md
+++ b/nemoclaw/README.md
@@ -1,0 +1,85 @@
+# Deploy the demos inside NemoClaw
+
+[NemoClaw](https://github.com/NVIDIA/NemoClaw) (NVIDIA) isn't another MCP host like Claude Code,
+Hermes, or Codex. It's a security runtime: it builds an **NVIDIA OpenShell sandbox** and runs an
+agent harness inside it under an explicit network-egress policy. Its `nemohermes` variant runs
+**Hermes**, so this is the [`hermes/`](../hermes/) integration deployed inside that sandbox. The
+NemoClaw-specific work is the egress policy that lets the sandboxed agent reach our hosted server.
+
+The hosted `hai-agent-platform` server fits best here: it's HTTP, so the sandbox only needs egress
+plus the key. The stdio demo servers would need the repo and `uv` baked into the image, which fights
+the sandbox model.
+
+## Prerequisites
+
+- Docker (NemoClaw builds a ~2.4 GB image and runs OpenShell + k3s).
+- An inference-provider credential to run the Hermes model (NVIDIA, Anthropic, Nous, or local
+  Ollama/vLLM). This is separate from `HAI_API_KEY`.
+- This repo's `HAI_API_KEY` (the `hk-` key the server authenticates with).
+
+## 1. Onboard from the custom image
+
+The stock Hermes sandbox ships an `mcp` package without the streamable-HTTP client, so the hosted
+server can't connect. [`image/Dockerfile`](image/Dockerfile) adds it at build time. Onboard from it:
+
+```bash
+export NEMOCLAW_AGENT=hermes
+nemohermes onboard --from nemoclaw/image/Dockerfile --name hai-hermes
+```
+
+The wizard asks for an inference provider, model, and credential. The build runs a check that fails
+if HTTP-MCP support didn't land, so a green build means the transport is in place.
+
+## 2. Allow egress to H Company
+
+The baseline Hermes policy permits Nous, PyPI, and NVIDIA endpoints, but not `agp.hcompany.ai`, so
+the server is blocked until you apply [`policies/hai-agent-platform.yaml`](policies/hai-agent-platform.yaml):
+
+```bash
+nemohermes hai-hermes policy-add --from-file nemoclaw/policies/hai-agent-platform.yaml
+nemohermes hai-hermes policy-list      # confirm agp.eu.hcompany.ai is listed
+```
+
+## 3. Register the server
+
+Hermes config lives at `/sandbox/.hermes/config.yaml` inside the sandbox (the host `~/.hermes` does
+not apply). Connect, then add the block with your real EU `hk-` key:
+
+```bash
+nemohermes hai-hermes connect
+```
+```yaml
+mcp_servers:
+  hai-agent-platform:
+    url: https://agp.eu.hcompany.ai/mcp
+    headers:
+      Authorization: "Bearer hk-...your-key..."
+    timeout: 420
+```
+
+## 4. Verify
+
+Inside the sandbox, the one-shot check (expect the six tools `run_agent`, `list_agents`,
+`wait_for_session`, `send_message`, `cancel_session`, `share_session`):
+
+```bash
+hermes mcp test hai-agent-platform
+```
+
+Then drive it through the agent: start the Hermes chat (the command `connect` prints) and ask it to
+"list the available H agents". To prove the call leaves the sandbox, run `openshell term` on the host
+while it runs; you'll see the request to `agp.eu.hcompany.ai:443` from the Hermes runtime. The browser
+dashboard (port 18789) is forwarded only while a `connect` session is open.
+
+## Notes
+
+- **The egress policy is the integration.** Without it, OpenShell blocks the call to agp. The
+  policy's `binaries` entry must match the runtime that makes the call, which in the NVIDIA Hermes
+  image is `/opt/hermes/.venv/bin/python3`. If a call is denied, `openshell term` names the binary
+  and host so you can adjust.
+- **Why a custom image.** The stock sandbox's `mcp` lacks `mcp.client.streamable_http`, and a runtime
+  install won't fix it: the venv is uv-managed (no `pip`), the egress policy blocks `uv` from PyPI,
+  and `uv` doesn't trust the image's patched CA bundle. Build time avoids all three, so the transport
+  goes in via [`image/Dockerfile`](image/Dockerfile).
+- For full blueprint examples (model, agent, and policy together), see
+  [NVIDIA/nemoclaw-community](https://github.com/NVIDIA/nemoclaw-community).

--- a/nemoclaw/image/Dockerfile
+++ b/nemoclaw/image/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+#
+# Custom NemoClaw Hermes sandbox image that adds streamable-HTTP MCP client support.
+# The stock hermes-sandbox-base ships an `mcp` package without `mcp.client.streamable_http`,
+# so the hosted hai-agent-platform server can't connect (`hermes mcp test` reports it missing).
+# Install it at BUILD time: normal networking and cert trust apply here, whereas at runtime the
+# OpenShell egress policy blocks uv from PyPI and uv doesn't use the image's patched CA bundle.
+#
+# Build and apply:
+#   nemohermes onboard --from nemoclaw/image/Dockerfile --name hai-hermes
+# (the Dockerfile's parent dir is the build context; keeping it in its own folder keeps that small)
+
+ARG BASE_IMAGE=ghcr.io/nvidia/nemoclaw/hermes-sandbox-base:latest
+FROM ${BASE_IMAGE}
+
+# Prefer Hermes' own [mcp] extra (pins matching versions); fall back to explicit packages.
+RUN uv pip install --python /opt/hermes/.venv/bin/python -e "/opt/hermes[mcp]" \
+ || uv pip install --python /opt/hermes/.venv/bin/python -U mcp httpx httpx-sse
+
+# Fail the build early if the HTTP client still isn't importable.
+RUN /opt/hermes/.venv/bin/python -c "import importlib.util as u; assert u.find_spec('mcp.client.streamable_http'), 'streamable_http still missing'"

--- a/nemoclaw/policies/hai-agent-platform.yaml
+++ b/nemoclaw/policies/hai-agent-platform.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# OpenShell network-policy preset that lets a NemoClaw (nemohermes) sandbox reach the H Company
+# agent platform. The baseline Hermes policy allows Nous, PyPI, NVIDIA inference, and messaging
+# endpoints, but NOT agp.hcompany.ai, so the hosted hai-agent-platform MCP server is blocked
+# without this preset. Schema mirrors NemoClaw's shipped presets (nemoclaw-blueprint/policies/presets/).
+#
+# Apply to a running sandbox:
+#   nemohermes <sandbox> policy-add --from-file nemoclaw/policies/hai-agent-platform.yaml
+# Or bake into the baseline: merge `network_policies` into agents/hermes/ (or
+# nemoclaw-blueprint/policies/) and re-run `nemohermes onboard`.
+
+preset:
+  name: hai-agent-platform
+  description: "H Company agent platform (agp): hosted MCP server + cloud agent API"
+
+network_policies:
+  hai-agent-platform:
+    name: hai-agent-platform
+    endpoints:
+      - host: agp.eu.hcompany.ai        # EU (the demos' default); use agp.hcompany.ai for US
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        rules:
+          # Scoped to one host. Narrow the path to /mcp for stricter least-privilege once you've
+          # confirmed the endpoint; the agent only talks to the hosted MCP proxy, not agp directly.
+          - allow: { method: GET, path: "/**" }    # SSE streams and reads
+          - allow: { method: POST, path: "/**" }   # MCP JSON-RPC
+    binaries:
+      # The NemoClaw Hermes runtime that makes the calls (verified via openshell term). If your
+      # image differs, a denied request in `openshell term` names the real binary path to use.
+      - { path: /opt/hermes/.venv/bin/python3 }


### PR DESCRIPTION
## Summary

Deploys the H agent-platform MCP server inside a NVIDIA NemoClaw sandbox running Hermes. 

NemoClaw isn't a separate MCP host; it runs Hermes under an enforced egress policy, so this extends the Hermes integration with the two OpenShell-specific pieces: an egress policy for `agp` and a sandbox image that adds streamable-HTTP MCP support.

## Changes

- `nemoclaw/policies/hai-agent-platform.yaml`: OpenShell egress preset for `agp.eu.hcompany.ai`, scoped to the verified Hermes runtime binary
- `nemoclaw/image/Dockerfile`: custom Hermes image that adds the streamable-HTTP `mcp` client (the stock one lacks it)
- `nemoclaw/README.md`: deploy guide (onboard, apply policy, register, verify)

## Verified live

Egress reaches `agp` once the policy binary matches `/opt/hermes/.venv/bin/python3`, and `hermes mcp test` lists the server's six tools.