### PR TITLE
[examples] Add add_to_cart and product_availability demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 Recipes for the [`hai-agents`](https://pypi.org/project/hai-agents/) Python SDK, wired up as **MCP servers and CLI tools for Claude Code**, and runnable in other MCP hosts ([Hermes Agent](hermes/), [Codex](codex/)), or deployed inside NVIDIA's [NemoClaw](nemoclaw/) sandbox. Each example shows one way to use the SDK in a real workflow.
 
-The SDK lets you spin up autonomous agents — web-surfing, code-running, vision-capable — and drive them from Python. This repo wraps that SDK into two interface patterns so you can call the agents from inside Claude Code while you work:
+The SDK lets you spin up autonomous agents that browse the web, run code, and read what's on screen, then drive them from Python. This repo wraps that SDK into two interface patterns so you can call the agents from inside Claude Code while you work:
 
-- **MCP server** — Claude Code calls the agent like any other MCP tool.
-- **CLI + Claude Code skill** — Claude Code runs a shell command that a skill knows how to invoke.
+- **MCP server:** Claude Code calls the agent like any other MCP tool.
+- **CLI + Claude Code skill:** Claude Code runs a shell command that a skill knows how to invoke.
 
 ## Quickstart
 
@@ -21,7 +21,7 @@ claude                 # opens Claude Code in the repo; the MCP server is auto-r
 
 In Claude Code:
 
-> *"Use `review_web_ui` to check https://news.ycombinator.com — verify the top story link works and the page has reasonable accessibility."*
+> *"Use `review_web_ui` to check https://news.ycombinator.com and verify the top story link works and the page has reasonable accessibility."*
 
 https://github.com/user-attachments/assets/f0097089-033b-458b-8e20-2b59cc48b3a0
 
@@ -40,16 +40,16 @@ NemoClaw isn't a separate host: it runs Hermes inside an NVIDIA OpenShell sandbo
 
 ### Installing the dependencies
 
-The repo ships both a `pyproject.toml` (source of truth for dependencies, dev tools, and console scripts) and a `uv.lock` (pinned versions for reproducible installs). Use either tool — both pull the same packages from the same manifest.
+The repo ships both a `pyproject.toml` (source of truth for dependencies, dev tools, and console scripts) and a `uv.lock` (pinned versions for reproducible installs). Use either tool; both pull the same packages from the same manifest.
 
-**uv (recommended)** — fast, uses the lockfile, manages the virtualenv for you:
+**uv (recommended).** Fast, uses the lockfile, and manages the virtualenv for you:
 
 ```bash
 uv sync                            # installs runtime + dev deps into .venv/
 uv run qa-cli review --url ...     # runs the console script in the env
 ```
 
-**pip + venv** — same packages, no lockfile pin:
+**pip + venv.** Same packages, but no lockfile pin:
 
 ```bash
 python -m venv .venv && source .venv/bin/activate
@@ -57,7 +57,7 @@ pip install -e .                   # editable install of this repo's deps
 qa-cli review --url ...            # console scripts are on PATH inside the venv
 ```
 
-The `.mcp.json` registration assumes `uv run` is available — if you go the pip route, edit `.mcp.json` to invoke the console scripts directly (drop the `uv run --env-file .env` prefix and `source .venv/bin/activate` beforehand, or pass the venv's interpreter explicitly).
+The `.mcp.json` registration assumes `uv run` is available. If you go the pip route, edit `.mcp.json` to invoke the console scripts directly (drop the `uv run --env-file .env` prefix and `source .venv/bin/activate` beforehand, or pass the venv's interpreter explicitly).
 
 
 ## Skills
@@ -80,10 +80,10 @@ Each example is a self-contained recipe with its own README. See [`examples/`](e
 | --- | --- | --- |
 | [`qa/mcp`](examples/qa/mcp/README.md) | Autonomous browser agent QAs a remote URL and returns structured `{verdict, summary, findings}` | MCP server (`review_web_ui`, `visual_check`) |
 | [`qa/cli`](examples/qa/cli/README.md) | Same QA agent exposed as a shell command, surfaced to Claude Code via the `hai-qa-via-cli` skill | CLI (`qa-cli review / visual`) |
-| [`extract_anything`](examples/extract_anything/README.md) | Wrap an agent call as a typed Python function — generic `extract(url, task, schema)` or curated `get_*` tools — exposed as both MCP and CLI | MCP server (`extract`) + CLI (`extract-cli`) |
+| [`extract_anything`](examples/extract_anything/README.md) | Wrap an agent call as a typed Python function (generic `extract(url, task, schema)` or curated `get_*` tools), exposed as both MCP and CLI | MCP server (`extract`) + CLI (`extract-cli`) |
 | [`counterfeit_detection`](examples/counterfeit_detection/README.md) | Single-agent + custom-tools cookbook in three stages: bare `run_session`, then local screenshot-compare tools, then a `max_steps`/`max_time_s` budget for an exhaustive sweep | CLI (`counterfeit-cli simple / tooled / sweep`) |
 
-### Drive the straight from a natural-language prompt (Python)
+### Drive the agent straight from a natural-language prompt (Python)
 
 > Just describe the task in plain language and let the agent run it:
 
@@ -95,7 +95,7 @@ https://github.com/user-attachments/assets/aa7473f8-9666-4640-ac34-6255ab67aa6d
 
 → Runnable code: [`examples/add_to_cart/add_to_cart.py`](examples/add_to_cart/add_to_cart.py) (Python)
 
-### Or let the `/hai-agents` skill generate the SDK code for you — TypeScript (as in this example) or Python
+### Or let the `/hai-agents` skill generate the SDK code for you: TypeScript (as in this example) or Python
 
 > Ask the skill to write the SDK code, and it scaffolds a ready-to-run script:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # hai-agents-demos
 
 Recipes for the [`hai-agents`](https://pypi.org/project/hai-agents/) Python SDK, wired up as **MCP servers and CLI tools for Claude Code**, and runnable in other MCP hosts ([Hermes Agent](hermes/), [Codex](codex/)), or deployed inside NVIDIA's [NemoClaw](nemoclaw/) sandbox. Each example shows one way to use the SDK in a real workflow.
@@ -20,6 +22,9 @@ claude                 # opens Claude Code in the repo; the MCP server is auto-r
 In Claude Code:
 
 > *"Use `review_web_ui` to check https://news.ycombinator.com — verify the top story link works and the page has reasonable accessibility."*
+
+https://github.com/user-attachments/assets/f0097089-033b-458b-8e20-2b59cc48b3a0
+
 
 ### Run in Hermes Agent (Nous Research)
 
@@ -78,15 +83,15 @@ Each example is a self-contained recipe with its own README. See [`examples/`](e
 | [`extract_anything`](examples/extract_anything/README.md) | Wrap an agent call as a typed Python function — generic `extract(url, task, schema)` or curated `get_*` tools — exposed as both MCP and CLI | MCP server (`extract`) + CLI (`extract-cli`) |
 | [`counterfeit_detection`](examples/counterfeit_detection/README.md) | Single-agent + custom-tools cookbook in three stages: bare `run_session`, then local screenshot-compare tools, then a `max_steps`/`max_time_s` budget for an exhaustive sweep | CLI (`counterfeit-cli simple / tooled / sweep`) |
 
-
-
-### Drive the SDK straight from a natural-language prompt (Python)
+### Drive the straight from a natural-language prompt (Python)
 
 > Just describe the task in plain language and let the agent run it:
 
 ```text
 "Searches for "Random Access Memories" by Daft Punk, adds it to the shopping cart."
 ```
+
+https://github.com/user-attachments/assets/aa7473f8-9666-4640-ac34-6255ab67aa6d
 
 → Runnable code: [`examples/add_to_cart/add_to_cart.py`](examples/add_to_cart/add_to_cart.py) (Python)
 
@@ -97,6 +102,7 @@ Each example is a self-contained recipe with its own README. See [`examples/`](e
 ```text
 "/hai-agents:hai-agents Generate TypeScript code that navigates to jacquemus.com, searches for the France Jacquemus × Nike football jersey, checks its availability in sizes S and XXL, and reports the results clearly."
 ```
+https://github.com/user-attachments/assets/d7d82573-22bb-4e2a-a261-bb603bc576f3
 
 → Generated code: [`examples/product_availability/src/index.ts`](examples/product_availability/src/index.ts) (TypeScript)
 

--- a/README.md
+++ b/README.md
@@ -54,16 +54,6 @@ qa-cli review --url ...            # console scripts are on PATH inside the venv
 
 The `.mcp.json` registration assumes `uv run` is available — if you go the pip route, edit `.mcp.json` to invoke the console scripts directly (drop the `uv run --env-file .env` prefix and `source .venv/bin/activate` beforehand, or pass the venv's interpreter explicitly).
 
-## Examples
-
-Each example is a self-contained recipe with its own README. See [`examples/`](examples/README.md) for the full index and the shared architecture.
-
-| Example | What it shows | Interface |
-| --- | --- | --- |
-| [`qa/mcp`](examples/qa/mcp/README.md) | Autonomous browser agent QAs a remote URL and returns structured `{verdict, summary, findings}` | MCP server (`review_web_ui`, `visual_check`) |
-| [`qa/cli`](examples/qa/cli/README.md) | Same QA agent exposed as a shell command, surfaced to Claude Code via the `hai-qa-via-cli` skill | CLI (`qa-cli review / visual`) |
-| [`extract_anything`](examples/extract_anything/README.md) | Wrap an agent call as a typed Python function — generic `extract(url, task, schema)` or curated `get_*` tools — exposed as both MCP and CLI | MCP server (`extract`) + CLI (`extract-cli`) |
-| [`counterfeit_detection`](examples/counterfeit_detection/README.md) | Single-agent + custom-tools cookbook in three stages: bare `run_session`, then local screenshot-compare tools, then a `max_steps`/`max_time_s` budget for an exhaustive sweep | CLI (`counterfeit-cli simple / tooled / sweep`) |
 
 ## Skills
 
@@ -77,11 +67,44 @@ This repo doubles as a **Claude Code plugin marketplace**: each skill ([`hai-age
 
 The hosted `hai-agents-platform` server in [`.mcp.json`](.mcp.json) (the generic platform MCP, for any H agent) is HTTP, not stdio, so it can't read `.env` like the others: Claude Code expands `${HAI_API_KEY}` in its auth header from the environment. Export the key before launching (`export HAI_API_KEY=hk-...`). It uses the EU endpoint (the demos' default); swap to `agp.hcompany.ai` for US.
 
+## Examples
+
+Each example is a self-contained recipe with its own README. See [`examples/`](examples/README.md) for the full index and the shared architecture.
+
+| Example | What it shows | Interface |
+| --- | --- | --- |
+| [`qa/mcp`](examples/qa/mcp/README.md) | Autonomous browser agent QAs a remote URL and returns structured `{verdict, summary, findings}` | MCP server (`review_web_ui`, `visual_check`) |
+| [`qa/cli`](examples/qa/cli/README.md) | Same QA agent exposed as a shell command, surfaced to Claude Code via the `hai-qa-via-cli` skill | CLI (`qa-cli review / visual`) |
+| [`extract_anything`](examples/extract_anything/README.md) | Wrap an agent call as a typed Python function — generic `extract(url, task, schema)` or curated `get_*` tools — exposed as both MCP and CLI | MCP server (`extract`) + CLI (`extract-cli`) |
+| [`counterfeit_detection`](examples/counterfeit_detection/README.md) | Single-agent + custom-tools cookbook in three stages: bare `run_session`, then local screenshot-compare tools, then a `max_steps`/`max_time_s` budget for an exhaustive sweep | CLI (`counterfeit-cli simple / tooled / sweep`) |
+
+
+
+### Drive the SDK straight from a natural-language prompt (Python)
+
+> Just describe the task in plain language and let the agent run it:
+
+```text
+"Searches for "Random Access Memories" by Daft Punk, adds it to the shopping cart."
+```
+
+→ Runnable code: [`examples/add_to_cart/add_to_cart.py`](examples/add_to_cart/add_to_cart.py) (Python)
+
+### Or let the `/hai-agents` skill generate the SDK code for you — TypeScript (as in this example) or Python
+
+> Ask the skill to write the SDK code, and it scaffolds a ready-to-run script:
+
+```text
+"/hai-agents:hai-agents Generate TypeScript code that navigates to jacquemus.com, searches for the France Jacquemus × Nike football jersey, checks its availability in sizes S and XXL, and reports the results clearly."
+```
+
+→ Generated code: [`examples/product_availability/src/index.ts`](examples/product_availability/src/index.ts) (TypeScript)
+
 ## Project layout
 
 ```
 hai-agents-demos/
-├── examples/    qa · extract_anything · counterfeit_detection (+ _shared.py helpers)
+├── examples/    qa · extract_anything · counterfeit_detection · add_to_cart · product_availability (+ _shared.py helpers)
 ├── skills/      hai-agents · hai-qa-via-cli (published to the marketplace)
 ├── hermes/      run the same demos in Hermes Agent (config + setup guide)
 ├── codex/       run the same demos in OpenAI Codex (config.toml + setup guide)

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ Each subdirectory is one self-contained recipe for the `hai-agents` SDK.
 | [`qa/cli`](qa/cli/) | Same QA agent, exposed as a shell command (`qa-cli`) and surfaced to Claude via the `hai-qa-via-cli` skill instead of MCP. |
 | [`extract_anything`](extract_anything/) | One tool exposed two ways. MCP: `extract(url, task, schema)`. CLI: `extract-cli picture`. The cloud browser agent reads the page visually (Wikipedia's Picture of the Day in the CLI demo) and returns JSON matching the schema. |
 | [`counterfeit_detection`](counterfeit_detection/) | Cookbook for the single-agent + custom-tools pattern: find counterfeit listings of a genuine product. Three stages — a bare `run_session`, then local Playwright/Holo screenshot-compare tools, then a `max_steps`/`max_time_s` budget that turns "find one" into "find as many as the budget allows". |
+| [`add_to_cart`](add_to_cart/) | Minimal "drive the SDK straight" recipe (Python): a visual browser agent searches a shopping site for a product and adds it to the cart, printing the live agent-view link first. |
+| [`product_availability`](product_availability/) | The TypeScript counterpart: find a product on a store's site and report availability across sizes, with a `zod`-validated answer schema. |
 
 ## How it works
 

--- a/examples/add_to_cart/README.md
+++ b/examples/add_to_cart/README.md
@@ -1,7 +1,7 @@
 # add_to_cart (Python)
 
 Drive an H Computer-Use agent straight from the SDK: search a shopping site for a
-product and add it to the cart. The agent *sees* the page and clicks through the UI —
+product and add it to the cart. The agent *sees* the page and clicks through the UI;
 there's no store API involved. (This demo searches for Daft Punk's "Random Access
 Memories".)
 

--- a/examples/add_to_cart/README.md
+++ b/examples/add_to_cart/README.md
@@ -1,0 +1,20 @@
+# add_to_cart (Python)
+
+Drive an H Computer-Use agent straight from the SDK: search a shopping site for a
+product and add it to the cart. The agent *sees* the page and clicks through the UI —
+there's no store API involved. (This demo searches for Daft Punk's "Random Access
+Memories".)
+
+Single file: [`add_to_cart.py`](add_to_cart.py).
+
+## Run
+
+```bash
+# from the repo root, with HAI_API_KEY in your environment (or .env)
+python3 -m venv .hai-venv && .hai-venv/bin/pip install -q hai-agents
+source .env && .hai-venv/bin/python examples/add_to_cart/add_to_cart.py
+```
+
+The script prints the live `agent-view` link up front so you can watch the run, then
+reports the product title, format, price, and whether it was added to the cart. It
+never proceeds to checkout.

--- a/examples/add_to_cart/add_to_cart.py
+++ b/examples/add_to_cart/add_to_cart.py
@@ -1,0 +1,56 @@
+"""Drive an H Computer-Use agent to add Daft Punk's "Random Access Memories" to an Amazon cart.
+
+The agent *sees* Amazon and decides what to click/type/scroll — there's no Amazon API here.
+Run with:  source .env && .hai-venv/bin/python add_to_cart.py
+(Reads HAI_API_KEY from the environment — `source .env` first, or export it.)
+"""
+
+import os
+import sys
+from hai_agents import Client, wait_for_session
+
+# EU is the SDK default; the agent-view host below must match the region.
+AGENT_VIEW_HOST = "https://platform.eu.hcompany.ai"
+
+# A visual browser agent: it perceives the page and clicks through the UI (needed for "add to cart").
+AGENT = "h/web-surfer-pro"
+
+# The task is *what to do now* → goes in `messages`, never in `instructions`.
+TASK = """\
+Go to https://www.amazon.com. In the search bar, search for "Random Access Memories Daft Punk".
+
+From the results, open the main album listing for the Daft Punk album (prefer the CD or Vinyl
+music product, not a t-shirt or unrelated item). On the product page, click "Add to Cart".
+Then confirm the item is in the cart.
+Report the exact product title, format, price, and whether it was successfully added to the cart.
+Do NOT proceed to checkout or enter any payment information.
+"""
+
+
+def main() -> int:
+    api_key = os.environ.get("HAI_API_KEY")
+    if not api_key:
+        print("Missing HAI_API_KEY. `source .env` first, or export it in the environment.", file=sys.stderr)
+        return 1
+
+    # Pass the key explicitly: the repo's convention is HAI_API_KEY, while the Python
+    # SDK would otherwise look for H_API_KEY.
+    client = Client(api_key=api_key)
+
+    # Create the session first so we can print the live link *before* the run blocks.
+    session = client.sessions.create_session(agent=AGENT, messages=TASK)
+
+    live_url = f"{AGENT_VIEW_HOST}/agent-view/{session.id}"
+    print(f"Session : {session.id}", flush=True)
+    print(f"Watch   : {live_url}", flush=True)
+
+    # Block until the run settles, then report the agent's answer.
+    result = wait_for_session(client, session.id, timeout_seconds=600)
+    status = result.status if hasattr(result, "status") else "settled"
+    print(f"\nStatus  : {status}")
+    print(f"Answer  :\n{result.answer}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/add_to_cart/add_to_cart.py
+++ b/examples/add_to_cart/add_to_cart.py
@@ -1,8 +1,8 @@
 """Drive an H Computer-Use agent to add Daft Punk's "Random Access Memories" to an Amazon cart.
 
-The agent *sees* Amazon and decides what to click/type/scroll — there's no Amazon API here.
+The agent *sees* Amazon and decides what to click/type/scroll; there's no Amazon API here.
 Run with:  source .env && .hai-venv/bin/python add_to_cart.py
-(Reads HAI_API_KEY from the environment — `source .env` first, or export it.)
+(Reads HAI_API_KEY from the environment; `source .env` first, or export it.)
 """
 
 import os

--- a/examples/add_to_cart/add_to_cart.py
+++ b/examples/add_to_cart/add_to_cart.py
@@ -44,7 +44,6 @@ def main() -> int:
     print(f"Session : {session.id}", flush=True)
     print(f"Watch   : {live_url}", flush=True)
 
-    # Block until the run settles, then report the agent's answer.
     result = wait_for_session(client, session.id, timeout_seconds=600)
     status = result.status if hasattr(result, "status") else "settled"
     print(f"\nStatus  : {status}")

--- a/examples/product_availability/README.md
+++ b/examples/product_availability/README.md
@@ -2,7 +2,7 @@
 
 The TypeScript counterpart to [`add_to_cart`](../add_to_cart/): drive the `hai-agents`
 SDK from Node to find a product on a store's site and report its availability across
-sizes, returning a typed, `zod`-validated answer. (This demo looks up the France
+sizes. It returns a typed, `zod`-validated answer. (This demo looks up the France
 Jacquemus × Nike football jersey on jacquemus.com and checks sizes **S** and **XXL**.)
 
 Entry point: [`src/index.ts`](src/index.ts).

--- a/examples/product_availability/README.md
+++ b/examples/product_availability/README.md
@@ -1,0 +1,20 @@
+# product_availability (TypeScript)
+
+The TypeScript counterpart to [`add_to_cart`](../add_to_cart/): drive the `hai-agents`
+SDK from Node to find a product on a store's site and report its availability across
+sizes, returning a typed, `zod`-validated answer. (This demo looks up the France
+Jacquemus × Nike football jersey on jacquemus.com and checks sizes **S** and **XXL**.)
+
+Entry point: [`src/index.ts`](src/index.ts).
+
+## Run
+
+```bash
+cd examples/product_availability
+npm install
+# HAI_API_KEY must be in the environment or in examples/product_availability/.env
+npm start
+```
+
+Set `HAI_REGION=us` to target the US endpoint (EU is the default). The script prints the
+live `agent-view` link first, then a clear per-size availability report.

--- a/examples/product_availability/package.json
+++ b/examples/product_availability/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "hai-jersey",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "hai-agents": "^0.1.11",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/product_availability/src/index.ts
+++ b/examples/product_availability/src/index.ts
@@ -58,19 +58,18 @@ A size is AVAILABLE only if it can be selected and added to the bag (not greyed 
 Report the product name, URL, price, and the availability of each size.`;
 
 async function main(): Promise<void> {
-  // 1) Create the session; returns immediately with an id (does NOT block).
+  // Create the session; returns immediately with an id (does NOT block).
   const handle = await client.startSession({
     agent: "h/web-surfer-pro", // visual web agent, larger model, best for a real shopping flow
     messages: task,
     answerSchema: Availability,
   });
 
-  // 2) Print the live agent-view link FIRST, flushed, so the user can watch now.
+  // Print the live agent-view link first (flushed) so the user can watch now.
   const agentViewUrl = `https://${agentViewHost}/agent-view/${handle.id}`;
   console.log(`\n▶ Watch live: ${agentViewUrl}`);
   console.log(`  session id: ${handle.id}\n  working… (this can take a couple of minutes)\n`);
 
-  // 3) Block until the run settles, then read the typed answer.
   const result = await handle.waitForCompletion();
 
   console.log(`Session status: ${result.status}`);
@@ -81,7 +80,6 @@ async function main(): Promise<void> {
     return;
   }
 
-  // 4) Report clearly.
   console.log("\n================ RESULT ================");
   if (!answer.productFound) {
     console.log("❌ Could not find the France Jacquemus × Nike jersey on jacquemus.com.");

--- a/examples/product_availability/src/index.ts
+++ b/examples/product_availability/src/index.ts
@@ -1,0 +1,111 @@
+/**
+ * Find the France (FFF) Jacquemus × Nike football jersey on jacquemus.com,
+ * check availability in sizes S and XXL, and report the result.
+ *
+ * Uses the H Computer-Use Agent platform (hai-agents SDK):
+ *   - startSession()        -> returns a handle with .id IMMEDIATELY (no block)
+ *                              so we can print the live agent-view link up front
+ *   - handle.waitForCompletion() -> blocks until the run settles, returns the
+ *                              schema-validated answer
+ *
+ * Region: EU is the SDK default (agp.eu.hcompany.ai) -> the agent-view UI lives
+ * at platform.eu.hcompany.ai.
+ */
+import { HaiAgentsClient } from "hai-agents";
+import { z } from "zod";
+
+// The SDK reads HAI_API_KEY from the environment — `source .env` first, or export it.
+if (!process.env.HAI_API_KEY) {
+  console.error("Missing HAI_API_KEY. Run the hai-agents login or set it in the environment.");
+  process.exit(1);
+}
+
+// --- Region (EU is the default; flip to US by setting HAI_REGION=us) ----------
+const region = (process.env.HAI_REGION ?? "eu").toLowerCase();
+const agentViewHost =
+  region === "us" ? "platform.hcompany.ai" : "platform.eu.hcompany.ai";
+
+const client = new HaiAgentsClient(
+  region === "us" ? { environment: "https://agp.hcompany.ai" } : {}, // EU default needs no override
+);
+
+// --- Typed, schema-validated result we want back from the agent ---------------
+const SIZES = ["S", "XXL"] as const;
+
+const Availability = z.object({
+  productFound: z.boolean().describe("Whether the France Jacquemus x Nike jersey product page was found on jacquemus.com"),
+  productName: z.string().nullable().describe("Exact product title shown on the page"),
+  productUrl: z.string().nullable().describe("URL of the product page"),
+  price: z.string().nullable().describe("Listed price as shown, including currency"),
+  sizes: z
+    .array(
+      z.object({
+        size: z.string().describe('Size label, e.g. "S" or "XXL"'),
+        available: z.boolean().describe("True if this size can be added to the cart / is in stock"),
+        note: z.string().nullable().describe('Optional detail, e.g. "Sold out" or "Low stock"'),
+      }),
+    )
+    .describe("Availability for each requested size (S and XXL)"),
+  summary: z.string().describe("One- or two-sentence plain-language summary of the findings"),
+});
+
+const task = `Go to jacquemus.com and find the France national team (FFF) football shirt / jersey from the Jacquemus x Nike collaboration.
+
+Use the on-site search or the menu (search terms like "France", "Nike", "football", "jersey", "maillot", "FFF").
+Open the correct product page for that jersey.
+Then determine whether each of these sizes is available to add to the cart: ${SIZES.join(", ")}.
+A size is AVAILABLE only if it can be selected and added to the bag (not greyed out / not 'Sold Out' / not 'Notify me').
+Report the product name, URL, price, and the availability of each size.`;
+
+async function main(): Promise<void> {
+  // 1) Create the session — returns immediately with an id (does NOT block).
+  const handle = await client.startSession({
+    agent: "h/web-surfer-pro", // visual web agent, larger model — best for a real shopping flow
+    messages: task,
+    answerSchema: Availability,
+  });
+
+  // 2) Print the live agent-view link FIRST, flushed, so the user can watch now.
+  const agentViewUrl = `https://${agentViewHost}/agent-view/${handle.id}`;
+  console.log(`\n▶ Watch live: ${agentViewUrl}`);
+  console.log(`  session id: ${handle.id}\n  working… (this can take a couple of minutes)\n`);
+
+  // 3) Block until the run settles, then read the typed answer.
+  const result = await handle.waitForCompletion();
+
+  console.log(`Session status: ${result.status}`);
+  const answer = result.answer;
+  if (!answer) {
+    console.log("No structured answer was returned. Final text/changes:");
+    console.log(JSON.stringify(result.finalChanges?.answer ?? null, null, 2));
+    return;
+  }
+
+  // 4) Report clearly.
+  console.log("\n================ RESULT ================");
+  if (!answer.productFound) {
+    console.log("❌ Could not find the France Jacquemus × Nike jersey on Nike.");
+  } else {
+    console.log(`Product : ${answer.productName ?? "(name not captured)"}`);
+    if (answer.price) console.log(`Price   : ${answer.price}`);
+    if (answer.productUrl) console.log(`URL     : ${answer.productUrl}`);
+    console.log("\nRequested sizes:");
+    for (const size of SIZES) {
+      const found = answer.sizes.find((s) => s.size.toUpperCase() === size);
+      if (!found) {
+        console.log(`  • ${size.padEnd(4)} → ❓ not reported`);
+      } else {
+        const mark = found.available ? "✅ available" : "❌ unavailable";
+        console.log(`  • ${found.size.padEnd(4)} → ${mark}${found.note ? ` (${found.note})` : ""}`);
+      }
+    }
+  }
+  console.log(`\nSummary : ${answer.summary}`);
+  console.log("========================================\n");
+  console.log(`Replay : ${agentViewUrl}`);
+}
+
+main().catch((err) => {
+  console.error("Run failed:", err);
+  process.exit(1);
+});

--- a/examples/product_availability/src/index.ts
+++ b/examples/product_availability/src/index.ts
@@ -14,7 +14,7 @@
 import { HaiAgentsClient } from "hai-agents";
 import { z } from "zod";
 
-// The SDK reads HAI_API_KEY from the environment — `source .env` first, or export it.
+// The SDK reads HAI_API_KEY from the environment; `source .env` first, or export it.
 if (!process.env.HAI_API_KEY) {
   console.error("Missing HAI_API_KEY. Run the hai-agents login or set it in the environment.");
   process.exit(1);
@@ -58,9 +58,9 @@ A size is AVAILABLE only if it can be selected and added to the bag (not greyed 
 Report the product name, URL, price, and the availability of each size.`;
 
 async function main(): Promise<void> {
-  // 1) Create the session — returns immediately with an id (does NOT block).
+  // 1) Create the session; returns immediately with an id (does NOT block).
   const handle = await client.startSession({
-    agent: "h/web-surfer-pro", // visual web agent, larger model — best for a real shopping flow
+    agent: "h/web-surfer-pro", // visual web agent, larger model, best for a real shopping flow
     messages: task,
     answerSchema: Availability,
   });
@@ -84,7 +84,7 @@ async function main(): Promise<void> {
   // 4) Report clearly.
   console.log("\n================ RESULT ================");
   if (!answer.productFound) {
-    console.log("❌ Could not find the France Jacquemus × Nike jersey on Nike.");
+    console.log("❌ Could not find the France Jacquemus × Nike jersey on jacquemus.com.");
   } else {
     console.log(`Product : ${answer.productName ?? "(name not captured)"}`);
     if (answer.price) console.log(`Price   : ${answer.price}`);


### PR DESCRIPTION
## Summary

Add two standalone "drive the SDK directly" recipes — `add_to_cart` (Python) and `product_availability` (TypeScript) — that spin up an H Computer-Use agent against a live site and report the result, plus the README/docs updates to surface them.