### PR TITLE
[docs] Restructure README around discover/scale/integrate narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # hai-agents-demos
 
-Build with H's Computer Use autonomous agents, powered by our own harness and our [own VLM](https://hcompany.ai/holo3.1). When the target system exposes no API, our agents operate it directly through the UI.
+Build with H's Computer-Use Agents, powered by our harness and [VLM](https://hcompany.ai/holo3.1). A Computer-Use Agent sees the screen and decides what to click, type, and scroll, just like a person would. You describe a task in plain language; H provisions the environment, runs the agent, and returns the result. It's the way in when the work lives behind a UI with no API to call.
 
 The `hai-agents` SDK gives you programmatic access to our agents from a few lines of [Python](https://pypi.org/project/hai-agents/) or [TypeScript](https://npmjs.com/package/hai-agents).
 
 This repo is a tour of three ways to build with the SDK, from a one-line prompt to production integrations:
 
 1. **Discover.** Describe a task in plain language and watch the agent run it.
-2. **Scale via the skill.** Let the `/hai-agents` skill scaffold reusable SDK code for you.
-3. **Integrate.** Call the agent as an MCP tool from your coding workflow (Claude Code, Hermes Agent, Codex, NemoClaw).
+2. **Build with the skill** Let the `/hai-agents` skill scaffold reusable SDK code for you.
+3. **Integrate** Call the agent as an MCP tool from your coding workflow (Claude Code, Hermes Agent, Codex, NemoClaw).
 
 ## Quickstart
 
@@ -21,7 +21,7 @@ cp .env.example .env   # add your HAI_API_KEY from https://platform.hcompany.ai/
 
 ## 1. Discover
 
-One prompt, one Python file. You write 10 lines; the agent does the work. Now you've seen our CU agent in action.
+Use the SDK directly. The example below is a single Python file: a few lines of the `hai-agents` SDK wrapped around a plain-language prompt. You write the prompt, the SDK runs the agent, and you've seen a CU agent in action.
 
 > Just describe the task in plain language and let the agent run it:
 
@@ -33,9 +33,16 @@ https://github.com/user-attachments/assets/aa7473f8-9666-4640-ac34-6255ab67aa6d
 
 → Runnable code: [`examples/add_to_cart/add_to_cart.py`](examples/add_to_cart/add_to_cart.py) (Python)
 
-## 2. Scale via the skill
+## 2. Build with the skill
 
-The `/hai-agents` skill plugs into your favorite coding agent and writes the SDK code for you, in Python or TypeScript. You get a packaged expert writing your code, and an artifact you can deploy anywhere Python or Node runs, independent of the coding agent that scaffolded it. Iterate on prompts to grow your CU agent library.
+The [`/hai-agents`](skills/hai-agents) skill plugs into your coding agent and carries everything it needs to write SDK code for you: the full API knowledge, the auth and connection patterns, and enough context to write working SDK code quickly, in Python or TypeScript. You get a packaged expert writing your custom code, and an artifact you can deploy anywhere Python or Node runs, independent of the coding agent that scaffolded it. Iterate on prompts to grow your CU agent library.
+
+This repo also doubles as a [Claude Code plugin marketplace](skills/README.md), so you can install the skill into your own Claude Code without cloning anything:
+
+```
+/plugin marketplace add hcompai/hai-agents-demos
+/plugin install hai-agents@hai-skills
+```
 
 > Ask the skill to write the SDK code, and it scaffolds a ready-to-run script:
 
@@ -51,13 +58,9 @@ For deeper SDK patterns beyond what the skill scaffolds (custom tools, `max_step
 
 ## 3. Integrate
 
-Call the agent from your coding workflow over MCP. Same SDK, different host wiring.
+Now put the agent where you already work. MCP turns it into a first-class tool inside your coding workflow, Claude Code below, plus Hermes, Codex, NemoClaw, or anything that speaks MCP. One agent, many hosts, wiring is the only difference.
 
 Example with Claude Code:
-
-```bash
-claude                 # opens Claude Code in the repo; the MCP server is auto-registered
-```
 
 > *"Use `review_web_ui` to check https://news.ycombinator.com and verify the top story link works and the page has reasonable accessibility."*
 
@@ -65,10 +68,10 @@ https://github.com/user-attachments/assets/f0097089-033b-458b-8e20-2b59cc48b3a0
 
 ### Other hosts
 
+- **Claude Code** (Anthropic). The MCP server is auto-registered from [`.mcp.json`](.mcp.json) when you open the repo, so the agent's tools are available the moment you run `claude`.
 - **Hermes Agent** (Nous Research). Consumes the same MCP servers, skills, and CLIs. See [`hermes/`](hermes/) for the one-time setup.
 - **Codex** (OpenAI). Same servers in `config.toml` form; the hosted platform server uses `bearer_token_env_var`. Watch Codex's 60 s default tool timeout. See [`codex/`](codex/).
 - **NemoClaw** (HAI x NVIDIA x Hermes). A security runtime for regulated, sandboxed deployments, not another MCP host. It builds an NVIDIA OpenShell sandbox and runs Hermes inside it under a network-egress policy. The wiring is the Hermes integration plus an egress policy that lets the agent reach H's hosted server. See [`nemoclaw/`](nemoclaw/).
-- **Any other MCP-speaking client.** Same SDK, different wiring.
 
 ### Recipes
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # hai-agents-demos
 
-Build with H's Computer Use autonomous agents. When the target system exposes no API, our agents operate it directly through the UI — powered by our own harness and our [own VLM](https://hcompany.ai/holo3.1).
+Build with H's Computer Use autonomous agents, powered by our own harness and our [own VLM](https://hcompany.ai/holo3.1). When the target system exposes no API, our agents operate it directly through the UI.
 
 The `hai-agents` SDK gives you programmatic access to our agents from a few lines of [Python](https://pypi.org/project/hai-agents/) or [TypeScript](https://npmjs.com/package/hai-agents).
 
 This repo is a tour of three ways to build with the SDK, from a one-line prompt to production integrations:
 
-1. **Discover** — describe a task in plain language and watch the agent run it.
-2. **Scale via the skill** — let the `/hai-agents` skill scaffold reusable SDK code for you.
-3. **Integrate** — call the agent as an MCP tool from your coding workflow (Claude Code, Hermes Agent, Codex, NemoClaw).
+1. **Discover.** Describe a task in plain language and watch the agent run it.
+2. **Scale via the skill.** Let the `/hai-agents` skill scaffold reusable SDK code for you.
+3. **Integrate.** Call the agent as an MCP tool from your coding workflow (Claude Code, Hermes Agent, Codex, NemoClaw).
 
 ## Quickstart
 
@@ -26,7 +26,7 @@ One prompt, one Python file. You write 10 lines; the agent does the work. Now yo
 > Just describe the task in plain language and let the agent run it:
 
 ```text
-"Searches for "Random Access Memories" by Daft Punk, adds it to the shopping cart."
+"Searches for "Random Access Memories" by Daft Punk on Amazon, adds it to the shopping cart."
 ```
 
 https://github.com/user-attachments/assets/aa7473f8-9666-4640-ac34-6255ab67aa6d
@@ -35,7 +35,7 @@ https://github.com/user-attachments/assets/aa7473f8-9666-4640-ac34-6255ab67aa6d
 
 ## 2. Scale via the skill
 
-The `/hai-agents` skill plugs into your favorite coding agent and writes the SDK code for you, in **Python or TypeScript**. You get a packaged expert writing your code, and an artifact you can deploy anywhere Python or Node runs — independent of the coding agent that scaffolded it. Iterate on prompts to grow your library of CU agents fast.
+The `/hai-agents` skill plugs into your favorite coding agent and writes the SDK code for you, in Python or TypeScript. You get a packaged expert writing your code, and an artifact you can deploy anywhere Python or Node runs, independent of the coding agent that scaffolded it. Iterate on prompts to grow your CU agent library.
 
 > Ask the skill to write the SDK code, and it scaffolds a ready-to-run script:
 
@@ -46,6 +46,8 @@ The `/hai-agents` skill plugs into your favorite coding agent and writes the SDK
 https://github.com/user-attachments/assets/d7d82573-22bb-4e2a-a261-bb603bc576f3
 
 → Generated code: [`examples/product_availability/src/index.ts`](examples/product_availability/src/index.ts) (TypeScript)
+
+For deeper SDK patterns beyond what the skill scaffolds (custom tools, `max_steps` / `max_time_s` budgets, exhaustive sweeps), see [`examples/counterfeit_detection`](examples/counterfeit_detection/README.md).
 
 ## 3. Integrate
 
@@ -63,21 +65,20 @@ https://github.com/user-attachments/assets/f0097089-033b-458b-8e20-2b59cc48b3a0
 
 ### Other hosts
 
-- **Hermes Agent** (Nous Research) — consumes the same MCP servers, skills, and CLIs. See [`hermes/`](hermes/) for the one-time setup.
-- **Codex** (OpenAI) — same servers in `config.toml` form; the hosted platform server uses `bearer_token_env_var`. Watch Codex's 60 s default tool timeout. See [`codex/`](codex/).
-- **NemoClaw** (HAI x NVIDIA x Hermes) — a security runtime, not another MCP host. It builds an NVIDIA OpenShell sandbox and runs Hermes inside it under an explicit network-egress policy — designed for regulated, sandboxed deployments. The wiring is the Hermes integration plus an egress policy that lets the agent reach H's hosted server. See [`nemoclaw/`](nemoclaw/).
-- **Any other MCP-speaking client** — same SDK, different wiring.
+- **Hermes Agent** (Nous Research). Consumes the same MCP servers, skills, and CLIs. See [`hermes/`](hermes/) for the one-time setup.
+- **Codex** (OpenAI). Same servers in `config.toml` form; the hosted platform server uses `bearer_token_env_var`. Watch Codex's 60 s default tool timeout. See [`codex/`](codex/).
+- **NemoClaw** (HAI x NVIDIA x Hermes). A security runtime for regulated, sandboxed deployments, not another MCP host. It builds an NVIDIA OpenShell sandbox and runs Hermes inside it under a network-egress policy. The wiring is the Hermes integration plus an egress policy that lets the agent reach H's hosted server. See [`nemoclaw/`](nemoclaw/).
+- **Any other MCP-speaking client.** Same SDK, different wiring.
 
-## Examples
-
-Each example is a self-contained recipe with its own README. See [`examples/`](examples/README.md) for the full index and the shared architecture.
+### Recipes
 
 | Example | What it shows | Interface |
 | --- | --- | --- |
 | [`qa/mcp`](examples/qa/mcp/README.md) | Autonomous browser agent QAs a remote URL and returns structured `{verdict, summary, findings}` | MCP server (`review_web_ui`, `visual_check`) |
-| [`qa/cli`](examples/qa/cli/README.md) | Same QA agent exposed as a shell command, surfaced to Claude Code via the `hai-qa-via-cli` skill | CLI (`qa-cli review / visual`) |
+| [`qa/cli`](examples/qa/cli/README.md) | Same QA agent exposed as a shell command, surfaced to coding agents via the `hai-qa-via-cli` skill | CLI (`qa-cli review / visual`) |
 | [`extract_anything`](examples/extract_anything/README.md) | Wrap an agent call as a typed Python function (generic `extract(url, task, schema)` or curated `get_*` tools), exposed as both MCP and CLI | MCP server (`extract`) + CLI (`extract-cli`) |
-| [`counterfeit_detection`](examples/counterfeit_detection/README.md) | Single-agent + custom-tools cookbook in three stages: bare `run_session`, then local screenshot-compare tools, then a `max_steps`/`max_time_s` budget for an exhaustive sweep | CLI (`counterfeit-cli simple / tooled / sweep`) |
+
+See [`examples/`](examples/README.md) for the full index and shared architecture.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hai-agents-demos
 
-Build with H's Computer Use autonomous agents. When the target system exposes no API, our agents operate it directly through the UI — powered by our own harness and our own VLM (TODO: blog post link).
+Build with H's Computer Use autonomous agents. When the target system exposes no API, our agents operate it directly through the UI — powered by our own harness and our [own VLM](https://hcompany.ai/holo3.1).
 
 The `hai-agents` SDK gives you programmatic access to our agents from a few lines of [Python](https://pypi.org/project/hai-agents/) or [TypeScript](https://npmjs.com/package/hai-agents).
 
@@ -49,29 +49,24 @@ https://github.com/user-attachments/assets/d7d82573-22bb-4e2a-a261-bb603bc576f3
 
 ## 3. Integrate
 
-Call the agent from your coding workflow over MCP. Claude Code, Hermes Agent, Codex, and NemoClaw all speak MCP — same SDK, different host wiring.
+Call the agent from your coding workflow over MCP. Same SDK, different host wiring.
+
+Example with Claude Code:
 
 ```bash
 claude                 # opens Claude Code in the repo; the MCP server is auto-registered
 ```
 
-In Claude Code:
-
 > *"Use `review_web_ui` to check https://news.ycombinator.com and verify the top story link works and the page has reasonable accessibility."*
 
 https://github.com/user-attachments/assets/f0097089-033b-458b-8e20-2b59cc48b3a0
 
-### Run in Hermes Agent (Nous Research)
+### Other hosts
 
-These demos aren't limited to Claude Code. Hermes Agent consumes the same MCP servers, agentskills.io skills, and CLIs, so the SDK code is unchanged and only the host wiring differs. See [`hermes/`](hermes/) for the one-time setup (a config block plus a tool-call timeout bump).
-
-### Run in Codex (OpenAI)
-
-Codex is an MCP client too. See [`codex/`](codex/) for the same servers in `config.toml` form, including the hosted platform server via `bearer_token_env_var`. Mind Codex's 60 s default tool timeout.
-
-### Deploy inside NVIDIA NemoClaw
-
-NemoClaw isn't a separate host: it runs Hermes inside an NVIDIA OpenShell sandbox. So this is the Hermes integration deployed there, plus an egress policy that lets the sandboxed agent reach `agp`. See [`nemoclaw/`](nemoclaw/).
+- **Hermes Agent** (Nous Research) — consumes the same MCP servers, skills, and CLIs. See [`hermes/`](hermes/) for the one-time setup.
+- **Codex** (OpenAI) — same servers in `config.toml` form; the hosted platform server uses `bearer_token_env_var`. Watch Codex's 60 s default tool timeout. See [`codex/`](codex/).
+- **NemoClaw** (HAI x NVIDIA x Hermes) — a security runtime, not another MCP host. It builds an NVIDIA OpenShell sandbox and runs Hermes inside it under an explicit network-egress policy — designed for regulated, sandboxed deployments. The wiring is the Hermes integration plus an egress policy that lets the agent reach H's hosted server. See [`nemoclaw/`](nemoclaw/).
+- **Any other MCP-speaking client** — same SDK, different wiring.
 
 ## Examples
 
@@ -84,27 +79,6 @@ Each example is a self-contained recipe with its own README. See [`examples/`](e
 | [`extract_anything`](examples/extract_anything/README.md) | Wrap an agent call as a typed Python function (generic `extract(url, task, schema)` or curated `get_*` tools), exposed as both MCP and CLI | MCP server (`extract`) + CLI (`extract-cli`) |
 | [`counterfeit_detection`](examples/counterfeit_detection/README.md) | Single-agent + custom-tools cookbook in three stages: bare `run_session`, then local screenshot-compare tools, then a `max_steps`/`max_time_s` budget for an exhaustive sweep | CLI (`counterfeit-cli simple / tooled / sweep`) |
 
-## Installing the dependencies
-
-The repo ships both a `pyproject.toml` (source of truth for dependencies, dev tools, and console scripts) and a `uv.lock` (pinned versions for reproducible installs). Use either tool; both pull the same packages from the same manifest.
-
-**uv (recommended).** Fast, uses the lockfile, and manages the virtualenv for you:
-
-```bash
-uv sync                            # installs runtime + dev deps into .venv/
-uv run qa-cli review --url ...     # runs the console script in the env
-```
-
-**pip + venv.** Same packages, but no lockfile pin:
-
-```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -e .                   # editable install of this repo's deps
-qa-cli review --url ...            # console scripts are on PATH inside the venv
-```
-
-The `.mcp.json` registration assumes `uv run` is available. If you go the pip route, edit `.mcp.json` to invoke the console scripts directly (drop the `uv run --env-file .env` prefix and `source .venv/bin/activate` beforehand, or pass the venv's interpreter explicitly).
-
 ## Configuration
 
 | Env var | Required | Source |
@@ -113,16 +87,12 @@ The `.mcp.json` registration assumes `uv run` is available. If you go the pip ro
 
 The hosted `hai-agents-platform` server in [`.mcp.json`](.mcp.json) (the generic platform MCP, for any H agent) is HTTP, not stdio, so it can't read `.env` like the others: Claude Code expands `${HAI_API_KEY}` in its auth header from the environment. Export the key before launching (`export HAI_API_KEY=hk-...`). It uses the EU endpoint (the demos' default); swap to `agp.hcompany.ai` for US.
 
-## Skills
-
-See [`skills/`](skills/README.md) for the [`/hai-agents`](skills/hai-agents/) and [`/hai-qa-via-cli`](skills/hai-qa-via-cli/) skills.
-
 ## Project layout
 
 ```
 hai-agents-demos/
 ├── examples/    qa · extract_anything · counterfeit_detection · add_to_cart · product_availability (+ _shared.py helpers)
-├── skills/      hai-agents · hai-qa-via-cli (published to the marketplace)
+├── skills/      /hai-agents · /hai-qa-via-cli skills for your coding agent
 ├── hermes/      run the same demos in Hermes Agent (config + setup guide)
 ├── codex/       run the same demos in OpenAI Codex (config.toml + setup guide)
 ├── nemoclaw/    deploy the Hermes integration inside NVIDIA NemoClaw's sandbox (egress policy + image + guide)
@@ -130,6 +100,18 @@ hai-agents-demos/
 ├── .claude-plugin/marketplace.json
 └── pyproject.toml · AGENTS.md
 ```
+
+## Installation alternatives
+
+Quickstart uses `uv sync`. If you prefer pip, the same packages are in `pyproject.toml`:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e .                   # editable install of this repo's deps
+qa-cli review --url ...            # console scripts are on PATH inside the venv
+```
+
+The `.mcp.json` registration assumes `uv run` is available. If you go the pip route, edit `.mcp.json` to invoke the console scripts directly (drop the `uv run --env-file .env` prefix and `source .venv/bin/activate` beforehand, or pass the venv's interpreter explicitly).
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-
-
 # hai-agents-demos
 
-Recipes for the [`hai-agents`](https://pypi.org/project/hai-agents/) Python SDK, wired up as **MCP servers and CLI tools for Claude Code**, and runnable in other MCP hosts ([Hermes Agent](hermes/), [Codex](codex/)), or deployed inside NVIDIA's [NemoClaw](nemoclaw/) sandbox. Each example shows one way to use the SDK in a real workflow.
+Build with H's Computer Use autonomous agents. When the target system exposes no API, our agents operate it directly through the UI — powered by our own harness and our own VLM (TODO: blog post link).
 
-The SDK lets you spin up autonomous agents that browse the web, run code, and read what's on screen, then drive them from Python. This repo wraps that SDK into two interface patterns so you can call the agents from inside Claude Code while you work:
+The `hai-agents` SDK gives you programmatic access to our agents from a few lines of [Python](https://pypi.org/project/hai-agents/) or [TypeScript](https://npmjs.com/package/hai-agents).
 
-- **MCP server:** Claude Code calls the agent like any other MCP tool.
-- **CLI + Claude Code skill:** Claude Code runs a shell command that a skill knows how to invoke.
+This repo is a tour of three ways to build with the SDK, from a one-line prompt to production integrations:
+
+1. **Discover** — describe a task in plain language and watch the agent run it.
+2. **Scale via the skill** — let the `/hai-agents` skill scaffold reusable SDK code for you.
+3. **Integrate** — call the agent as an MCP tool from your coding workflow (Claude Code, Hermes Agent, Codex, NemoClaw).
 
 ## Quickstart
 
@@ -16,6 +17,41 @@ git clone <this-repo>
 cd hai-agents-demos
 uv sync
 cp .env.example .env   # add your HAI_API_KEY from https://platform.hcompany.ai/settings/api-keys
+```
+
+## 1. Discover
+
+One prompt, one Python file. You write 10 lines; the agent does the work. Now you've seen our CU agent in action.
+
+> Just describe the task in plain language and let the agent run it:
+
+```text
+"Searches for "Random Access Memories" by Daft Punk, adds it to the shopping cart."
+```
+
+https://github.com/user-attachments/assets/aa7473f8-9666-4640-ac34-6255ab67aa6d
+
+→ Runnable code: [`examples/add_to_cart/add_to_cart.py`](examples/add_to_cart/add_to_cart.py) (Python)
+
+## 2. Scale via the skill
+
+The `/hai-agents` skill plugs into your favorite coding agent and writes the SDK code for you, in **Python or TypeScript**. You get a packaged expert writing your code, and an artifact you can deploy anywhere Python or Node runs — independent of the coding agent that scaffolded it. Iterate on prompts to grow your library of CU agents fast.
+
+> Ask the skill to write the SDK code, and it scaffolds a ready-to-run script:
+
+```text
+"/hai-agents:hai-agents Generate TypeScript code that navigates to jacquemus.com, searches for the France Jacquemus × Nike football jersey, checks its availability in sizes S and XXL, and reports the results clearly."
+```
+
+https://github.com/user-attachments/assets/d7d82573-22bb-4e2a-a261-bb603bc576f3
+
+→ Generated code: [`examples/product_availability/src/index.ts`](examples/product_availability/src/index.ts) (TypeScript)
+
+## 3. Integrate
+
+Call the agent from your coding workflow over MCP. Claude Code, Hermes Agent, Codex, and NemoClaw all speak MCP — same SDK, different host wiring.
+
+```bash
 claude                 # opens Claude Code in the repo; the MCP server is auto-registered
 ```
 
@@ -24,7 +60,6 @@ In Claude Code:
 > *"Use `review_web_ui` to check https://news.ycombinator.com and verify the top story link works and the page has reasonable accessibility."*
 
 https://github.com/user-attachments/assets/f0097089-033b-458b-8e20-2b59cc48b3a0
-
 
 ### Run in Hermes Agent (Nous Research)
 
@@ -38,7 +73,18 @@ Codex is an MCP client too. See [`codex/`](codex/) for the same servers in `conf
 
 NemoClaw isn't a separate host: it runs Hermes inside an NVIDIA OpenShell sandbox. So this is the Hermes integration deployed there, plus an egress policy that lets the sandboxed agent reach `agp`. See [`nemoclaw/`](nemoclaw/).
 
-### Installing the dependencies
+## Examples
+
+Each example is a self-contained recipe with its own README. See [`examples/`](examples/README.md) for the full index and the shared architecture.
+
+| Example | What it shows | Interface |
+| --- | --- | --- |
+| [`qa/mcp`](examples/qa/mcp/README.md) | Autonomous browser agent QAs a remote URL and returns structured `{verdict, summary, findings}` | MCP server (`review_web_ui`, `visual_check`) |
+| [`qa/cli`](examples/qa/cli/README.md) | Same QA agent exposed as a shell command, surfaced to Claude Code via the `hai-qa-via-cli` skill | CLI (`qa-cli review / visual`) |
+| [`extract_anything`](examples/extract_anything/README.md) | Wrap an agent call as a typed Python function (generic `extract(url, task, schema)` or curated `get_*` tools), exposed as both MCP and CLI | MCP server (`extract`) + CLI (`extract-cli`) |
+| [`counterfeit_detection`](examples/counterfeit_detection/README.md) | Single-agent + custom-tools cookbook in three stages: bare `run_session`, then local screenshot-compare tools, then a `max_steps`/`max_time_s` budget for an exhaustive sweep | CLI (`counterfeit-cli simple / tooled / sweep`) |
+
+## Installing the dependencies
 
 The repo ships both a `pyproject.toml` (source of truth for dependencies, dev tools, and console scripts) and a `uv.lock` (pinned versions for reproducible installs). Use either tool; both pull the same packages from the same manifest.
 
@@ -59,11 +105,6 @@ qa-cli review --url ...            # console scripts are on PATH inside the venv
 
 The `.mcp.json` registration assumes `uv run` is available. If you go the pip route, edit `.mcp.json` to invoke the console scripts directly (drop the `uv run --env-file .env` prefix and `source .venv/bin/activate` beforehand, or pass the venv's interpreter explicitly).
 
-
-## Skills
-
-This repo doubles as a **Claude Code plugin marketplace**: each skill ([`hai-agents`](skills/hai-agents/), [`hai-qa-via-cli`](skills/hai-qa-via-cli/)) is published under the `hai-skills` marketplace so it can be installed without cloning. See [`skills/`](skills/README.md) for install instructions and how to add your own.
-
 ## Configuration
 
 | Env var | Required | Source |
@@ -72,39 +113,9 @@ This repo doubles as a **Claude Code plugin marketplace**: each skill ([`hai-age
 
 The hosted `hai-agents-platform` server in [`.mcp.json`](.mcp.json) (the generic platform MCP, for any H agent) is HTTP, not stdio, so it can't read `.env` like the others: Claude Code expands `${HAI_API_KEY}` in its auth header from the environment. Export the key before launching (`export HAI_API_KEY=hk-...`). It uses the EU endpoint (the demos' default); swap to `agp.hcompany.ai` for US.
 
-## Examples
+## Skills
 
-Each example is a self-contained recipe with its own README. See [`examples/`](examples/README.md) for the full index and the shared architecture.
-
-| Example | What it shows | Interface |
-| --- | --- | --- |
-| [`qa/mcp`](examples/qa/mcp/README.md) | Autonomous browser agent QAs a remote URL and returns structured `{verdict, summary, findings}` | MCP server (`review_web_ui`, `visual_check`) |
-| [`qa/cli`](examples/qa/cli/README.md) | Same QA agent exposed as a shell command, surfaced to Claude Code via the `hai-qa-via-cli` skill | CLI (`qa-cli review / visual`) |
-| [`extract_anything`](examples/extract_anything/README.md) | Wrap an agent call as a typed Python function (generic `extract(url, task, schema)` or curated `get_*` tools), exposed as both MCP and CLI | MCP server (`extract`) + CLI (`extract-cli`) |
-| [`counterfeit_detection`](examples/counterfeit_detection/README.md) | Single-agent + custom-tools cookbook in three stages: bare `run_session`, then local screenshot-compare tools, then a `max_steps`/`max_time_s` budget for an exhaustive sweep | CLI (`counterfeit-cli simple / tooled / sweep`) |
-
-### Drive the agent straight from a natural-language prompt (Python)
-
-> Just describe the task in plain language and let the agent run it:
-
-```text
-"Searches for "Random Access Memories" by Daft Punk, adds it to the shopping cart."
-```
-
-https://github.com/user-attachments/assets/aa7473f8-9666-4640-ac34-6255ab67aa6d
-
-→ Runnable code: [`examples/add_to_cart/add_to_cart.py`](examples/add_to_cart/add_to_cart.py) (Python)
-
-### Or let the `/hai-agents` skill generate the SDK code for you: TypeScript (as in this example) or Python
-
-> Ask the skill to write the SDK code, and it scaffolds a ready-to-run script:
-
-```text
-"/hai-agents:hai-agents Generate TypeScript code that navigates to jacquemus.com, searches for the France Jacquemus × Nike football jersey, checks its availability in sizes S and XXL, and reports the results clearly."
-```
-https://github.com/user-attachments/assets/d7d82573-22bb-4e2a-a261-bb603bc576f3
-
-→ Generated code: [`examples/product_availability/src/index.ts`](examples/product_availability/src/index.ts) (TypeScript)
+See [`skills/`](skills/README.md) for the [`/hai-agents`](skills/hai-agents/) and [`/hai-qa-via-cli`](skills/hai-qa-via-cli/) skills.
 
 ## Project layout
 


### PR DESCRIPTION
## Summary

Repositions the README so the first impression establishes hai-agents as H's Computer Use agent platform (own VLM + own harness), not as MCP plugins for Claude Code. Host integrations remain — they move from headline to section 3 as one path among several.

## Changes

- **Positioning**: leads with H's CU value prop (target system exposes no API → our agents operate it directly through the UI, powered by our own harness and our own VLM) instead of "Recipes wired up as MCP servers and CLI tools for Claude Code"
- **New section structure**: `## 1. Discover` / `## 2. Scale via the skill` / `## 3. Integrate`
  - Section 1: Daft Punk natural-language prompt + video + [`add_to_cart.py`](examples/add_to_cart/add_to_cart.py) (moved from former bottom section)
  - Section 2: `/hai-agents` skill scaffolds reusable SDK code in Python or TS — emphasizes portability (artifact runs anywhere Python/Node runs, independent of the coding agent). Jacquemus prompt + video + [`product_availability/src/index.ts`](examples/product_availability/src/index.ts)
  - Section 3: Claude Code MCP quickstart + `review_web_ui` HN review demo + video, plus Hermes / Codex / NemoClaw subsections